### PR TITLE
Enable C++ modules for CLHEP

### DIFF
--- a/Exceptions/Exceptions/ZMexHandler.h
+++ b/Exceptions/Exceptions/ZMexHandler.h
@@ -103,7 +103,7 @@ public:
     ZMhandleTo<ZMexHandlerBehavior>( behaviorWanted )
   { }
 
-  virtual ~ZMexHandler() { }
+  virtual ~ZMexHandler();
 
   std::string name() const {
     return  rep_->name();

--- a/Exceptions/src/ZMerrno.cc
+++ b/Exceptions/src/ZMerrno.cc
@@ -26,6 +26,7 @@
 
 #include "CLHEP/Exceptions/ZMexception.h"
 
+#include <string>
 
 namespace zmex  {
 

--- a/Exceptions/src/ZMexClassInfo.cc
+++ b/Exceptions/src/ZMexClassInfo.cc
@@ -16,6 +16,9 @@
 
 #include "CLHEP/Exceptions/ZMexClassInfo.h"
 
+#include "CLHEP/Exceptions/ZMexSeverity.h"
+
+#include <string>
 
 namespace zmex  {
 

--- a/Exceptions/src/ZMexHandler.cc
+++ b/Exceptions/src/ZMexHandler.cc
@@ -17,11 +17,17 @@
 
 #include "CLHEP/Exceptions/ZMexHandler.h"
 
+#include "CLHEP/Exceptions/ZMexAction.h"
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexLogResult.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
+
+#include <string>
 
 
 namespace zmex  {
 
+ZMexHandler::~ZMexHandler() { }
 
 //******************************************
 //

--- a/Exceptions/src/ZMexLogger.cc
+++ b/Exceptions/src/ZMexLogger.cc
@@ -22,7 +22,10 @@
 
 #include "CLHEP/Exceptions/ZMexLogger.h"
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/RefCount/ZMhandleTo.h"
 
+#include <iostream>
+#include <string>
 
 // ----------------------------------------------------------------------
 

--- a/Exceptions/src/ZMexSeverity.cc
+++ b/Exceptions/src/ZMexSeverity.cc
@@ -12,6 +12,10 @@
 
 #include "CLHEP/Exceptions/ZMexSeverity.h"
 
+#include "CLHEP/Exceptions/ZMerrno.h"
+
+#include <string>
+
 
 namespace zmex  {
 

--- a/Exceptions/src/ZMexception.cc
+++ b/Exceptions/src/ZMexception.cc
@@ -34,9 +34,11 @@
 #include "CLHEP/Exceptions/defs.h"
 #include "CLHEP/Exceptions/ZMexception.h"
 #include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
 #include "CLHEP/Exceptions/ZMexHandler.h"
 #include "CLHEP/Exceptions/ZMexLogger.h"
 #include "CLHEP/Exceptions/ZMexLogResult.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 
 #include <sstream>
 #include <ctime>

--- a/Exceptions/src/ZMthrow.cc
+++ b/Exceptions/src/ZMthrow.cc
@@ -15,10 +15,12 @@
 
 
 #include "CLHEP/Exceptions/ZMthrow.h"
-#include "CLHEP/Exceptions/ZMexSeverity.h"
-#include "CLHEP/Exceptions/ZMexception.h"
 #include "CLHEP/Exceptions/ZMerrno.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 
+#include <string>
 
 namespace zmex  {
 

--- a/Exceptions/test/exctest1.cc
+++ b/Exceptions/test/exctest1.cc
@@ -4,6 +4,9 @@ using std::endl;
 
 
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 #include "CLHEP/Exceptions/ZMthrow.h"
 using namespace zmex;
 

--- a/Exceptions/test/exctest4.cc
+++ b/Exceptions/test/exctest4.cc
@@ -4,6 +4,9 @@ using std::endl;
 
 
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 #include "CLHEP/Exceptions/ZMthrow.h"
 using namespace zmex;
 

--- a/Exceptions/test/exctestNothrow.cc
+++ b/Exceptions/test/exctestNothrow.cc
@@ -8,10 +8,16 @@
 
 #include "CLHEP/Exceptions/ZMthrow.h"
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 #include "CLHEP/Exceptions/ZMerrno.h"
+
 using namespace zmex;
 
+#include <iostream>
 #include <fstream>
+
 using namespace std;
 
 

--- a/Exceptions/test/testExceptions.cc
+++ b/Exceptions/test/testExceptions.cc
@@ -20,8 +20,13 @@
 #include "CLHEP/Exceptions/defs.h"
 #include "CLHEP/Cast/itos.h"
 #include "CLHEP/Exceptions/ZMthrow.h"
-#include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 #include "CLHEP/Exceptions/ZMerrno.h"
+#include "CLHEP/Exceptions/ZMexception.h"
+
+#include <iostream>
 
 
 using namespace zmex;

--- a/Exceptions/test/testThrowFrom.cc
+++ b/Exceptions/test/testThrowFrom.cc
@@ -14,7 +14,11 @@
 
 #include "CLHEP/Exceptions/ZMthrow.h"
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 
+#include <iostream>
 using namespace zmex;
 
 ZMexStandardDefinition( ZMexception, ZMxTest );

--- a/Exceptions/test/testzmex.cc
+++ b/Exceptions/test/testzmex.cc
@@ -20,6 +20,9 @@
 
 #include "CLHEP/Exceptions/ZMthrow.h"
 #include "CLHEP/Exceptions/ZMexception.h"
+#include "CLHEP/Exceptions/ZMexAction.h"
+#include "CLHEP/Exceptions/ZMexClassInfo.h"
+#include "CLHEP/Exceptions/ZMexSeverity.h"
 #include "CLHEP/Exceptions/ZMerrno.h"
 
 

--- a/GenericFunctions/GenericFunctions/ButcherTableau.icc
+++ b/GenericFunctions/GenericFunctions/ButcherTableau.icc
@@ -1,3 +1,4 @@
+#include <ostream> // for std::endl
 namespace Genfun {
   ButcherTableau::ButcherTableau(const std::string &xname, unsigned int xorder):_name(xname),_order(xorder){
   }

--- a/GenericFunctions/GenericFunctions/ExtendedButcherTableau.icc
+++ b/GenericFunctions/GenericFunctions/ExtendedButcherTableau.icc
@@ -1,3 +1,4 @@
+#include <ostream> // for std::endl
 namespace Genfun {
   ExtendedButcherTableau::ExtendedButcherTableau(const std::string &mname, 
 						 unsigned int xorder,

--- a/GenericFunctions/GenericFunctions/FunctionTimesParameter.hh
+++ b/GenericFunctions/GenericFunctions/FunctionTimesParameter.hh
@@ -12,6 +12,7 @@
 #include "CLHEP/GenericFunctions/AbsFunction.hh"
 
 namespace Genfun {
+  class Argument;
 
   /**
    * @author

--- a/GenericFunctions/src/ASin.cc
+++ b/GenericFunctions/src/ASin.cc
@@ -1,5 +1,6 @@
 // -*- C++ -*-
 // $Id: ASin.cc,v 1.4 2003/10/10 17:40:39 garren Exp $
+#include "CLHEP/GenericFunctions/AbsFunction.hh"
 #include "CLHEP/GenericFunctions/ASin.hh"
 #include "CLHEP/GenericFunctions/Sqrt.hh"
 #include "CLHEP/GenericFunctions/Square.hh"

--- a/GenericFunctions/src/AdaptiveRKStepper.cc
+++ b/GenericFunctions/src/AdaptiveRKStepper.cc
@@ -1,7 +1,10 @@
 #include "CLHEP/GenericFunctions/AdaptiveRKStepper.hh"
 #include "CLHEP/GenericFunctions/EmbeddedRKStepper.hh"
+
 #include <cmath>
 #include <stdexcept>
+#include <vector>
+
 namespace Genfun {
 
   AdaptiveRKStepper::AdaptiveRKStepper(const EEStepper *stepper):

--- a/GenericFunctions/src/AnalyticConvolution.cc
+++ b/GenericFunctions/src/AnalyticConvolution.cc
@@ -1,5 +1,6 @@
 // -*- C++ -*-
 // $Id: AnalyticConvolution.cc,v 1.8 2010/07/22 21:55:10 garren Exp $
+#include "CLHEP/GenericFunctions/AbsFunction.hh"
 #include "CLHEP/GenericFunctions/AnalyticConvolution.hh"
 #include "CLHEP/GenericFunctions/Gaussian.hh"
 #include "CLHEP/GenericFunctions/Exponential.hh"
@@ -7,6 +8,8 @@
 #if (defined _WIN32)
 #include <float.h> //  Visual C++ _finite
 #endif
+#include <iostream>
+
 namespace Genfun {
 FUNCTION_OBJECT_IMP(AnalyticConvolution)
 

--- a/GenericFunctions/src/ArrayFunction.cc
+++ b/GenericFunctions/src/ArrayFunction.cc
@@ -1,6 +1,9 @@
 // -*- C++ -*-
 // $Id: 
+#include "CLHEP/GenericFunctions/AbsFunction.hh"
 #include "CLHEP/GenericFunctions/ArrayFunction.hh"
+
+#include <vector>
 
 namespace Genfun {
 

--- a/GenericFunctions/src/BetaDistribution.cc
+++ b/GenericFunctions/src/BetaDistribution.cc
@@ -4,6 +4,7 @@
 #include "CLHEP/GenericFunctions/BetaDistribution.hh"
 #include <assert.h>
 #include <cmath>
+#include <iostream>
 using namespace std;
 
 namespace Genfun {

--- a/GenericFunctions/src/BivariateGaussian.cc
+++ b/GenericFunctions/src/BivariateGaussian.cc
@@ -4,6 +4,7 @@
 #include "CLHEP/GenericFunctions/BivariateGaussian.hh"
 #include <assert.h>
 #include <cmath>      // for exp()
+#include <iostream>
 
 #if (defined __STRICT_ANSI__) || (defined _WIN32)
 #ifndef M_PI

--- a/GenericFunctions/src/DefiniteIntegral.cc
+++ b/GenericFunctions/src/DefiniteIntegral.cc
@@ -1,12 +1,13 @@
 // -*- C++ -*-
 // $Id: DefiniteIntegral.cc,v 1.6 2010/06/16 18:22:01 garren Exp $
 
+#include "CLHEP/GenericFunctions/AbsFunction.hh"
+#include "CLHEP/GenericFunctions/DefiniteIntegral.hh"
+
 #include <cmath>
+#include <iostream>
 #include <vector>
 #include <stdexcept>
-#include "CLHEP/GenericFunctions/DefiniteIntegral.hh"
-#include "CLHEP/GenericFunctions/AbsFunction.hh"
-
 
 namespace Genfun {
 

--- a/GenericFunctions/src/EfficiencyFunctional.cc
+++ b/GenericFunctions/src/EfficiencyFunctional.cc
@@ -5,6 +5,7 @@
 #include "CLHEP/GenericFunctions/AbsFunction.hh"
 #include <iostream>
 #include <cmath>      // for log()
+#include <vector>
 
 namespace Genfun {
 EfficiencyFunctional::EfficiencyFunctional(const ArgumentList & aList):

--- a/GenericFunctions/src/EmbeddedRKStepper.cc
+++ b/GenericFunctions/src/EmbeddedRKStepper.cc
@@ -1,6 +1,8 @@
 #include "CLHEP/GenericFunctions/EmbeddedRKStepper.hh"
 #include "CLHEP/GenericFunctions/ExtendedButcherTableau.hh"
 #include <stdexcept>
+#include <vector>
+
 namespace Genfun {
 
   

--- a/GenericFunctions/src/Exponential.cc
+++ b/GenericFunctions/src/Exponential.cc
@@ -3,6 +3,7 @@
 #include "CLHEP/GenericFunctions/Exponential.hh"
 #include <assert.h>
 #include <cmath>      // for exp()
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(Exponential)

--- a/GenericFunctions/src/FunctionComposition.cc
+++ b/GenericFunctions/src/FunctionComposition.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionComposition.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionComposition.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionComposition)

--- a/GenericFunctions/src/FunctionConvolution.cc
+++ b/GenericFunctions/src/FunctionConvolution.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionConvolution.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionConvolution.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionConvolution)

--- a/GenericFunctions/src/FunctionDifference.cc
+++ b/GenericFunctions/src/FunctionDifference.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionDifference.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionDifference.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionDifference)

--- a/GenericFunctions/src/FunctionDirectProduct.cc
+++ b/GenericFunctions/src/FunctionDirectProduct.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionDirectProduct.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionDirectProduct.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionDirectProduct)

--- a/GenericFunctions/src/FunctionProduct.cc
+++ b/GenericFunctions/src/FunctionProduct.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionProduct.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionProduct.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionProduct)

--- a/GenericFunctions/src/FunctionQuotient.cc
+++ b/GenericFunctions/src/FunctionQuotient.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionQuotient.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionQuotient.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionQuotient)

--- a/GenericFunctions/src/FunctionSum.cc
+++ b/GenericFunctions/src/FunctionSum.cc
@@ -2,6 +2,7 @@
 // $Id: FunctionSum.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/FunctionSum.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(FunctionSum)

--- a/GenericFunctions/src/GammaDistribution.cc
+++ b/GenericFunctions/src/GammaDistribution.cc
@@ -4,6 +4,8 @@
 #include "CLHEP/GenericFunctions/GammaDistribution.hh"
 #include <assert.h>
 #include <cmath>
+#include <iostream>
+
 using namespace std;
 
 namespace Genfun {

--- a/GenericFunctions/src/Gaussian.cc
+++ b/GenericFunctions/src/Gaussian.cc
@@ -5,6 +5,7 @@
 #include "CLHEP/GenericFunctions/Variable.hh"
 #include <assert.h>
 #include <cmath>      // for exp()
+#include <iostream>
 
 #if (defined __STRICT_ANSI__) || (defined _WIN32)
 #ifndef M_PI

--- a/GenericFunctions/src/IncompleteGamma.cc
+++ b/GenericFunctions/src/IncompleteGamma.cc
@@ -4,6 +4,8 @@
 #include "CLHEP/GenericFunctions/IncompleteGamma.hh"
 #include <assert.h>
 #include <cmath>
+#include <iostream>
+
 using namespace std;
 
 namespace Genfun {

--- a/GenericFunctions/src/InterpolatingPolynomial.cc
+++ b/GenericFunctions/src/InterpolatingPolynomial.cc
@@ -4,6 +4,9 @@
 #include <cassert>
 #include <cmath>
 #include <cfloat>
+#include <iostream>
+#include <vector>
+
 namespace Genfun {
   FUNCTION_OBJECT_IMP(InterpolatingPolynomial)
   

--- a/GenericFunctions/src/Landau.cc
+++ b/GenericFunctions/src/Landau.cc
@@ -6,6 +6,7 @@
 #include "CLHEP/GenericFunctions/Variable.hh"
 #include <cmath>
 #include <assert.h>
+#include <iostream>
 
 using namespace std;
 

--- a/GenericFunctions/src/LikelihoodFunctional.cc
+++ b/GenericFunctions/src/LikelihoodFunctional.cc
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <cmath>      // for log()
+#include <vector>
 
 namespace Genfun {
 LikelihoodFunctional::LikelihoodFunctional(const ArgumentList & aList):

--- a/GenericFunctions/src/LogisticFunction.cc
+++ b/GenericFunctions/src/LogisticFunction.cc
@@ -3,6 +3,9 @@
 #include "CLHEP/GenericFunctions/LogisticFunction.hh"
 #include "CLHEP/GenericFunctions/Variable.hh"
 #include <assert.h>
+#include <iostream>
+#include <vector>
+
 #define MAXRANGE 1000
 
 namespace Genfun {

--- a/GenericFunctions/src/NonrelativisticBW.cc
+++ b/GenericFunctions/src/NonrelativisticBW.cc
@@ -2,6 +2,7 @@
 #include "CLHEP/GenericFunctions/Variable.hh"
 #include <assert.h>
 #include <cmath>
+#include <iostream>
 
 #if (defined __STRICT_ANSI__) || (defined _WIN32)
 #ifndef M_PI

--- a/GenericFunctions/src/Parameter.cc
+++ b/GenericFunctions/src/Parameter.cc
@@ -2,6 +2,8 @@
 // $Id: Parameter.cc,v 1.3 2003/09/06 14:04:14 boudreau Exp $
 #include "CLHEP/GenericFunctions/Parameter.hh"
 
+#include <iostream>
+
 namespace Genfun {
 PARAMETER_OBJECT_IMP(Parameter)
 

--- a/GenericFunctions/src/PeriodicRectangular.cc
+++ b/GenericFunctions/src/PeriodicRectangular.cc
@@ -4,6 +4,7 @@
 #include "CLHEP/GenericFunctions/FixedConstant.hh"
 #include <assert.h>
 #include <cmath>      // for floor()
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(PeriodicRectangular)

--- a/GenericFunctions/src/PtRelFcn.cc
+++ b/GenericFunctions/src/PtRelFcn.cc
@@ -6,6 +6,7 @@
 #include <assert.h>
 #include <cmath>	// for pow() and exp() and isfinite()
 #include <float.h>
+#include <iostream>
 
 #if (defined __STRICT_ANSI__) || (defined _WIN32)
 #ifndef M_PI

--- a/GenericFunctions/src/PuncturedSmearedExp.cc
+++ b/GenericFunctions/src/PuncturedSmearedExp.cc
@@ -3,6 +3,8 @@
 #include "CLHEP/GenericFunctions/PuncturedSmearedExp.hh"
 #include <sstream>
 #include <cmath>
+#include <vector>
+
 namespace Genfun {
 FUNCTION_OBJECT_IMP(PuncturedSmearedExp)
 

--- a/GenericFunctions/src/RKIntegrator.cc
+++ b/GenericFunctions/src/RKIntegrator.cc
@@ -4,7 +4,10 @@
 #include "CLHEP/GenericFunctions/AdaptiveRKStepper.hh"
 #include "CLHEP/GenericFunctions/Variable.hh"
 #include <climits>
+#include <memory>
 #include <stdexcept>
+#include <vector>
+
 namespace Genfun {
 FUNCTION_OBJECT_IMP(RKIntegrator::RKFunction)
 

--- a/GenericFunctions/src/Rectangular.cc
+++ b/GenericFunctions/src/Rectangular.cc
@@ -3,6 +3,7 @@
 #include "CLHEP/GenericFunctions/Rectangular.hh"
 #include "CLHEP/GenericFunctions/FixedConstant.hh"
 #include <assert.h>
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(Rectangular)

--- a/GenericFunctions/src/RelativisticBW.cc
+++ b/GenericFunctions/src/RelativisticBW.cc
@@ -2,6 +2,7 @@
 #include "CLHEP/GenericFunctions/Variable.hh"
 #include <assert.h>
 #include <cmath>
+#include <iostream>
 
 #if (defined __STRICT_ANSI__) || (defined _WIN32)
 #ifndef M_PI

--- a/GenericFunctions/src/ReverseExponential.cc
+++ b/GenericFunctions/src/ReverseExponential.cc
@@ -3,6 +3,7 @@
 #include "CLHEP/GenericFunctions/ReverseExponential.hh"
 #include <assert.h>
 #include <cmath>      // for exp()
+#include <iostream>
 
 namespace Genfun {
 FUNCTION_OBJECT_IMP(ReverseExponential)

--- a/GenericFunctions/src/RungeKuttaClassicalSolver.cc
+++ b/GenericFunctions/src/RungeKuttaClassicalSolver.cc
@@ -1,6 +1,10 @@
 #include "CLHEP/GenericFunctions/RungeKuttaClassicalSolver.hh"
 #include "CLHEP/GenericFunctions/RKIntegrator.hh"
 #include "CLHEP/GenericFunctions/AdaptiveRKStepper.hh"
+
+#include <iostream>
+#include <vector>
+
 namespace Classical {
   //
   // This is the private innards of RungeKuttaSolver

--- a/GenericFunctions/src/Sigma.cc
+++ b/GenericFunctions/src/Sigma.cc
@@ -2,7 +2,7 @@
 // $Id: 
 #include "CLHEP/GenericFunctions/Sigma.hh"
 #include <assert.h>
-
+#include <vector>
 namespace Genfun {
 FUNCTION_OBJECT_IMP(Sigma)
 

--- a/GenericFunctions/src/SimpleRKStepper.cc
+++ b/GenericFunctions/src/SimpleRKStepper.cc
@@ -1,6 +1,8 @@
 #include "CLHEP/GenericFunctions/SimpleRKStepper.hh"
 #include <cmath>
 #include <stdexcept>
+#include <vector>
+
 namespace Genfun {
   SimpleRKStepper::SimpleRKStepper(const ButcherTableau & mtableau,double xstepsize):
     tableau(mtableau),

--- a/GenericFunctions/src/StepDoublingRKStepper.cc
+++ b/GenericFunctions/src/StepDoublingRKStepper.cc
@@ -1,6 +1,7 @@
 #include "CLHEP/GenericFunctions/StepDoublingRKStepper.hh"
 #include <stdexcept>
 #include <cmath>
+#include <vector>
 namespace Genfun {
 
   

--- a/GenericFunctions/src/TrivariateGaussian.cc
+++ b/GenericFunctions/src/TrivariateGaussian.cc
@@ -6,6 +6,7 @@
 #include "CLHEP/GenericFunctions/TrivariateGaussian.hh"
 #include <assert.h>
 #include <cmath>      // for exp()
+#include <iostream>
 
 #if (defined __STRICT_ANSI__) || (defined _WIN32)
 #ifndef M_PI

--- a/GenericFunctions/test/testGenericFunctions.cc
+++ b/GenericFunctions/test/testGenericFunctions.cc
@@ -5,6 +5,7 @@
 #include <float.h>
 #include <cassert>
 #include <cmath>
+#include <iostream>
 
 
 int  main(int, char **) {

--- a/Geometry/test/testBasicVector3D.cc
+++ b/Geometry/test/testBasicVector3D.cc
@@ -2,13 +2,15 @@
 // $Id: testBasicVector3D.cc,v 1.5 2010/06/16 16:21:27 garren Exp $
 // ---------------------------------------------------------------------------
 
-#include <iostream>
-#include <assert.h>
 #include "CLHEP/Geometry/Point3D.h"
 #include "CLHEP/Geometry/Vector3D.h"
 #include "CLHEP/Geometry/Normal3D.h"
 #include "CLHEP/Geometry/Transform3D.h"
 #include "CLHEP/Units/PhysicalConstants.h"
+
+#include <assert.h>
+#include <cmath>
+#include <iostream>
 
 bool EQUAL(double a, double b) {
   double del = a - b;

--- a/Matrix/src/DiagMatrix.cc
+++ b/Matrix/src/DiagMatrix.cc
@@ -8,9 +8,6 @@
 #pragma implementation
 #endif
 
-#include <string.h>
-#include <cmath>
-
 #include "CLHEP/Matrix/defs.h"
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Matrix/DiagMatrix.h"
@@ -21,6 +18,11 @@
 #ifdef HEP_DEBUG_INLINE
 #include "CLHEP/Matrix/DiagMatrix.icc"
 #endif
+
+#include <iostream>
+#include <cmath>
+#include <string.h>
+
 
 namespace CLHEP {
 

--- a/Matrix/src/GenMatrix.cc
+++ b/Matrix/src/GenMatrix.cc
@@ -10,10 +10,6 @@
 #pragma implementation
 #endif
 
-#include <string.h>
-#include <cmath>
-#include <stdlib.h>
-
 #include "CLHEP/Matrix/GenMatrix.h"
 #include "CLHEP/Matrix/SymMatrix.h"
 #include "CLHEP/Matrix/Matrix.h"
@@ -21,6 +17,12 @@
 #ifdef HEP_DEBUG_INLINE
 #include "CLHEP/Matrix/GenMatrix.icc"
 #endif
+
+#include <cmath>
+#include <iostream>
+#include <string.h>
+#include <stdlib.h>
+
 
 namespace CLHEP {
 

--- a/Matrix/src/Matrix.cc
+++ b/Matrix/src/Matrix.cc
@@ -8,11 +8,6 @@
 #pragma implementation
 #endif
 
-#include <string.h>
-#include <float.h>        // for DBL_EPSILON
-#include <cmath>
-#include <stdlib.h>
-
 #include "CLHEP/Matrix/defs.h"
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Matrix/Matrix.h"
@@ -24,6 +19,14 @@
 #ifdef HEP_DEBUG_INLINE
 #include "CLHEP/Matrix/Matrix.icc"
 #endif
+
+#include <cmath>
+#include <iostream>
+#include <float.h>        // for DBL_EPSILON
+#include <stdlib.h>
+#include <string.h>
+
+
 
 namespace CLHEP {
 

--- a/Matrix/src/MatrixEqRotation.cc
+++ b/Matrix/src/MatrixEqRotation.cc
@@ -12,6 +12,8 @@
 #include "CLHEP/Matrix/Matrix.h"
 #include "CLHEP/Vector/Rotation.h"
 
+#include <iostream>
+
 namespace CLHEP {
 
 HepMatrix & HepMatrix::operator=(const HepRotation &hm1) {

--- a/Matrix/src/MatrixLinear.cc
+++ b/Matrix/src/MatrixLinear.cc
@@ -13,6 +13,9 @@
 #include "CLHEP/Matrix/Vector.h"
 #include "CLHEP/Matrix/SymMatrix.h"
 
+#include <iostream>
+#include <vector>
+
 namespace CLHEP {
 
 static int sign(double x) { return (x>0 ? 1: -1);}

--- a/Matrix/src/SymMatrix.cc
+++ b/Matrix/src/SymMatrix.cc
@@ -8,9 +8,6 @@
 #pragma implementation
 #endif
 
-#include <string.h>
-#include <float.h>        // for DBL_EPSILON
-
 #include "CLHEP/Matrix/defs.h"
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Matrix/SymMatrix.h"
@@ -21,6 +18,12 @@
 #ifdef HEP_DEBUG_INLINE
 #include "CLHEP/Matrix/SymMatrix.icc"
 #endif
+
+#include <iostream>
+#include <float.h>        // for DBL_EPSILON
+#include <string.h>
+
+
 
 namespace CLHEP {
 

--- a/Matrix/src/Vector.cc
+++ b/Matrix/src/Vector.cc
@@ -5,8 +5,6 @@
 #pragma implementation
 #endif
 
-#include <string.h>
-
 #include "CLHEP/Matrix/defs.h"
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Vector/ThreeVector.h"
@@ -17,6 +15,9 @@
 #ifdef HEP_DEBUG_INLINE
 #include "CLHEP/Matrix/Vector.icc"
 #endif
+
+#include <iostream>
+#include <string.h>
 
 namespace CLHEP {
 

--- a/Matrix/test/testBug104262.cc
+++ b/Matrix/test/testBug104262.cc
@@ -3,6 +3,8 @@
 
 #include "CLHEP/Matrix/Vector.h"
 
+#include <iostream>
+
 int main(int, char **) {
 
 CLHEP::HepVector fXVector;

--- a/Random/Random/SeedTable.h
+++ b/Random/Random/SeedTable.h
@@ -20,6 +20,7 @@
 #define SeedTable_h 1
 
 #include "CLHEP/Random/defs.h"
+#include "CLHEP/Random/Random.h"
 
 namespace CLHEP {
 

--- a/Random/Random/engineIDulong.h
+++ b/Random/Random/engineIDulong.h
@@ -16,6 +16,8 @@
 #ifndef engineIDulong_h
 #define engineIDulong_h 1
 
+#include <string>
+
 namespace CLHEP {
 
 unsigned long crc32ul(const std::string & s);

--- a/Random/src/DRand48Engine.cc
+++ b/Random/src/DRand48Engine.cc
@@ -40,6 +40,11 @@
 
 //#define TRACE_IO
 
+#include <ostream>
+#include <string>
+#include <vector>
+#include <iostream>
+
 namespace CLHEP {
 
 static const int MarkerLen = 64; // Enough room to hold a begin or end marker. 

--- a/Random/src/DoubConv.cc
+++ b/Random/src/DoubConv.cc
@@ -2,6 +2,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/DualRand.cc
+++ b/Random/src/DualRand.cc
@@ -56,7 +56,11 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
+#include <atomic>
+#include <ostream>
 #include <string.h>	// for strcmp
+#include <vector>
+#include <iostream>
 
 namespace CLHEP {
 

--- a/Random/src/EngineFactory.cc
+++ b/Random/src/EngineFactory.cc
@@ -31,6 +31,7 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include <iostream>
 #include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/Hurd160Engine.cc
+++ b/Random/src/Hurd160Engine.cc
@@ -34,8 +34,13 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
+#include <atomic>
 #include <cstdlib>	// for std::abs(int)
+#include <iostream>
+#include <ostream>
+#include <string.h>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/Hurd288Engine.cc
+++ b/Random/src/Hurd288Engine.cc
@@ -40,8 +40,12 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
+#include <atomic>
 #include <cstdlib>	// for std::abs(int)
+#include <iostream>
+#include <string.h>	// for strcmp
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/Random/src/JamesRandom.cc
+++ b/Random/src/JamesRandom.cc
@@ -43,9 +43,13 @@
 #include "CLHEP/Random/DoubConv.hh"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
+#include <iostream>
+#include <string.h>	// for strcmp
+#include <string>
+#include <vector>
 
 //#define TRACE_IO
 

--- a/Random/src/MTwistEngine.cc
+++ b/Random/src/MTwistEngine.cc
@@ -45,8 +45,11 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
-#include <cstdlib>	// for std::abs(int)
+#include <atomic>
+#include <cmath>
+#include <iostream>
+#include <string.h>        // for strcmp
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/MixMaxRng.cc
+++ b/Random/src/MixMaxRng.cc
@@ -36,8 +36,11 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>        // for strcmp
+#include <atomic>
 #include <cmath>
+#include <iostream>
+#include <string.h>        // for strcmp
+#include <vector>
 
 const unsigned long MASK32=0xffffffff;
 

--- a/Random/src/NonRandomEngine.cc
+++ b/Random/src/NonRandomEngine.cc
@@ -22,10 +22,11 @@
 #include "CLHEP/Random/NonRandomEngine.h"
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Random/DoubConv.hh"
+#include <cassert>
 #include <cstdlib>
 #include <iostream>
 #include <string>
-#include <cassert>
+#include <vector>
 
 //#define TRACE_IO
 

--- a/Random/src/RandBinomial.cc
+++ b/Random/src/RandBinomial.cc
@@ -22,6 +22,8 @@
 #include "CLHEP/Utility/thread_local.h"
 #include <algorithm>	// for min() and max()
 #include <cmath>	// for exp()
+#include <iostream>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandBit.cc
+++ b/Random/src/RandBit.cc
@@ -16,6 +16,7 @@
 
 #include "CLHEP/Random/defs.h"
 #include "CLHEP/Random/RandBit.h"
+#include <iostream>
 #include <string>
 
 namespace CLHEP {

--- a/Random/src/RandBreitWigner.cc
+++ b/Random/src/RandBreitWigner.cc
@@ -25,6 +25,9 @@
 #include "CLHEP/Random/DoubConv.hh"
 #include <algorithm>	// for min() and max()
 #include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandChiSquare.cc
+++ b/Random/src/RandChiSquare.cc
@@ -20,6 +20,9 @@
 #include "CLHEP/Random/DoubConv.hh"
 #include "CLHEP/Utility/thread_local.h"
 #include <cmath>	// for std::log()
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandEngine.cc
+++ b/Random/src/RandEngine.cc
@@ -42,8 +42,12 @@
 #include "CLHEP/Random/RandEngine.h"
 #include "CLHEP/Random/Random.h"
 #include "CLHEP/Random/engineIDulong.h"
-#include <string.h>	// for strcmp
+#include <cmath>
 #include <cstdlib>	// for int()
+#include <iostream>
+#include <string>
+#include <string.h>	// for strcmp
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandExpZiggurat.cc
+++ b/Random/src/RandExpZiggurat.cc
@@ -14,8 +14,9 @@
 
 #include "CLHEP/Random/RandExpZiggurat.h"
 
-#include <iostream>
 #include <cmath>	// for std::log()
+#include <iostream>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandExponential.cc
+++ b/Random/src/RandExponential.cc
@@ -22,6 +22,10 @@
 #include "CLHEP/Random/defs.h"
 #include "CLHEP/Random/RandExponential.h"
 #include "CLHEP/Random/DoubConv.hh"
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandFlat.cc
+++ b/Random/src/RandFlat.cc
@@ -30,7 +30,10 @@
 #include "CLHEP/Random/defs.h"
 #include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Random/DoubConv.hh"
+#include <iostream>
+#include <string>
 #include <string.h>	// for strcmp
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandGamma.cc
+++ b/Random/src/RandGamma.cc
@@ -20,6 +20,9 @@
 #include "CLHEP/Random/DoubConv.hh"
 #include "CLHEP/Utility/thread_local.h"
 #include <cmath>	// for std::log()
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandGauss.cc
+++ b/Random/src/RandGauss.cc
@@ -35,8 +35,11 @@
 #include "CLHEP/Random/defs.h"
 #include "CLHEP/Random/RandGauss.h"
 #include "CLHEP/Random/DoubConv.hh"
-#include <string.h>	// for strcmp
 #include <cmath>	// for std::log()
+#include <iostream>
+#include <string.h>	// for strcmp
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandGeneral.cc
+++ b/Random/src/RandGeneral.cc
@@ -51,6 +51,9 @@
 #include "CLHEP/Random/RandGeneral.h"
 #include "CLHEP/Random/DoubConv.hh"
 #include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandPoisson.cc
+++ b/Random/src/RandPoisson.cc
@@ -30,6 +30,9 @@
 #include "CLHEP/Units/PhysicalConstants.h"
 #include "CLHEP/Random/DoubConv.hh"
 #include <cmath>	// for std::floor()
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandPoissonQ.cc
+++ b/Random/src/RandPoissonQ.cc
@@ -44,6 +44,9 @@
 #include "CLHEP/Random/Stat.h"
 #include "CLHEP/Utility/thread_local.h"
 #include <cmath>	// for std::pow()
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RandPoissonT.cc
+++ b/Random/src/RandPoissonT.cc
@@ -29,6 +29,10 @@
 #include "CLHEP/Random/RandPoissonQ.h"
 #include "CLHEP/Random/DoubConv.hh"
 
+#include <iostream>
+#include <string>
+#include <vector>
+
 //
 // Constructors and destructors:
 //

--- a/Random/src/RandSkewNormal.cc
+++ b/Random/src/RandSkewNormal.cc
@@ -16,6 +16,11 @@
 #include "CLHEP/Random/RandGaussT.h"
 #include "CLHEP/Random/DoubConv.hh"
 
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
 namespace CLHEP {
 
 std::string RandSkewNormal::name() const {return "RandSkewNormal";}

--- a/Random/src/RandStudentT.cc
+++ b/Random/src/RandStudentT.cc
@@ -18,10 +18,14 @@
 // =======================================================================
 
 #include <float.h>
-#include <cmath>	// for std::log() std::exp()
 #include "CLHEP/Random/defs.h"
 #include "CLHEP/Random/RandStudentT.h"
 #include "CLHEP/Random/DoubConv.hh"
+
+#include <cmath>	// for std::log() std::exp()
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/Random.cc
+++ b/Random/src/Random.cc
@@ -18,7 +18,6 @@
 //                  initialisation of static generator: 5th Jan 1999
 // =======================================================================
 
-#include <assert.h>
 #include "CLHEP/Random/defs.h"
 #include "CLHEP/Random/MixMaxRng.h"
 #include "CLHEP/Random/Random.h"
@@ -32,6 +31,11 @@
 // -----------------------------
 
 #include "CLHEP/Random/SeedTable.h"
+
+#include <assert.h>
+#include <iostream>
+#include <type_traits>
+#include <string>
 
 namespace CLHEP {
 

--- a/Random/src/RandomEngine.cc
+++ b/Random/src/RandomEngine.cc
@@ -19,6 +19,9 @@
 #include "CLHEP/Random/RandomEngine.h"
 #include "CLHEP/Random/EngineFactory.h"
 
+#include <iostream>
+#include <vector>
+
 //------------------------- HepRandomEngine ------------------------------
 
 namespace CLHEP {

--- a/Random/src/RanecuEngine.cc
+++ b/Random/src/RanecuEngine.cc
@@ -43,9 +43,14 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
-#include <cmath>
+#include <atomic>
 #include <cstdlib>
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <string.h>	// for strcmp
+#include <vector>
+
 
 namespace CLHEP {
 

--- a/Random/src/Ranlux64Engine.cc
+++ b/Random/src/Ranlux64Engine.cc
@@ -60,9 +60,12 @@
 #include "CLHEP/Random/DoubConv.hh"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
+#include <atomic>
 #include <cstdlib>	// for std::abs(int)
+#include <iostream>
 #include <limits>	// for numeric_limits
+#include <string.h>	// for strcmp
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/src/RanluxEngine.cc
+++ b/Random/src/RanluxEngine.cc
@@ -43,8 +43,12 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
-#include <string.h>	// for strcmp
+#include <atomic>
 #include <cstdlib>	// for std::abs(int)
+#include <iostream>
+#include <string.h>	// for strcmp
+#include <string>
+#include <vector>
 
 #ifdef TRACE_IO
   #include "CLHEP/Random/DoubConv.hh"

--- a/Random/src/RanshiEngine.cc
+++ b/Random/src/RanshiEngine.cc
@@ -39,8 +39,11 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
+#include <atomic>
 #include <string.h>	// for strcmp
 #include <iostream>
+#include <string>
+#include <vector>
 
 // don't generate warnings about agressive loop optimization
 #if defined __GNUC__ 

--- a/Random/src/StaticRandomStates.cc
+++ b/Random/src/StaticRandomStates.cc
@@ -17,6 +17,7 @@
 #include "CLHEP/Random/StaticRandomStates.h"
 #include "CLHEP/Random/RandGauss.h"
 #include "CLHEP/Random/RandFlat.h"
+#include <iostream>
 #include <string>
 #include <sstream>
 

--- a/Random/src/TripleRand.cc
+++ b/Random/src/TripleRand.cc
@@ -42,7 +42,11 @@
 #include "CLHEP/Random/engineIDulong.h"
 #include "CLHEP/Utility/atomic_int.h"
 
+#include <atomic>
+#include <iostream>
 #include <string.h>	// for strcmp
+#include <string>
+#include <vector>
 
 namespace CLHEP {
 

--- a/Random/test/testBug58950.cc
+++ b/Random/test/testBug58950.cc
@@ -6,15 +6,15 @@
 // L. Garren	    12/1/09	rewritten for test suite
 // 
 // ----------------------------------------------------------------------
-#include <iostream> 
-#include <stdexcept>
-#include <cmath>
-#include <stdlib.h>
-#include <limits>
-#include <complex>
 #include "CLHEP/Random/RanecuEngine.h"
 #include "CLHEP/Random/Random.h"
 #include "pretend.h"
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <stdlib.h>
+#include <vector>
 
 bool printCheck( int & i, double & r, std::ofstream & os )
 {

--- a/Random/test/testDistCopy.cc
+++ b/Random/test/testDistCopy.cc
@@ -37,7 +37,7 @@
 // Standard library:
 #include <sstream>  // for ostringstream
 #include <string>   // for string
-
+#include <vector>
 
 using namespace CLHEP;
 typedef  unsigned int  uint;

--- a/RandomObjects/src/RandMultiGauss.cc
+++ b/RandomObjects/src/RandMultiGauss.cc
@@ -48,6 +48,7 @@
 #include "CLHEP/RandomObjects/RandMultiGauss.h"
 #include "CLHEP/RandomObjects/defs.h"
 #include <cmath>	// for log()
+#include <iostream>
 
 namespace CLHEP {
 

--- a/Utility/test/testSharedPtrConvertible.cc
+++ b/Utility/test/testSharedPtrConvertible.cc
@@ -17,6 +17,7 @@
 #include "CLHEP/Utility/memory.h"
 
 #include <cassert>
+#include <type_traits>
 
 #if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 6)
   #pragma GCC diagnostic push

--- a/Vector/Vector/ZMxpv.h
+++ b/Vector/Vector/ZMxpv.h
@@ -121,8 +121,9 @@
 //	If CLHEP ever embraces the ZOOM Exceptions mechanism, we will simply
 //	modify this file.
 
-#include <string>
 #include <exception>
+#include <iostream> // for std::cerr
+#include <string>
 
 #define ZMthrowA(A) do { std::cerr << A.name() << " thrown:\n" 	   \
              <<   A.what() << "\n" 					   \

--- a/Vector/src/AxisAngle.cc
+++ b/Vector/src/AxisAngle.cc
@@ -13,6 +13,10 @@
 
 #include "CLHEP/Vector/defs.h"
 #include "CLHEP/Vector/AxisAngle.h"
+#include "CLHEP/Vector/ThreeVector.h"
+
+#include <cmath>
+#include <ostream>
 
 namespace CLHEP  {
 

--- a/Vector/src/Boost.cc
+++ b/Vector/src/Boost.cc
@@ -16,6 +16,9 @@
 #include "CLHEP/Vector/LorentzRotation.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
+#include <iostream>
+
 namespace CLHEP  {
 
 // ----------  Constructors and Assignment:

--- a/Vector/src/BoostX.cc
+++ b/Vector/src/BoostX.cc
@@ -17,6 +17,9 @@
 #include "CLHEP/Vector/LorentzRotation.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
+#include <iostream>
+
 namespace CLHEP  {
 
 

--- a/Vector/src/BoostY.cc
+++ b/Vector/src/BoostY.cc
@@ -17,6 +17,9 @@
 #include "CLHEP/Vector/LorentzRotation.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
+#include <iostream>
+
 namespace CLHEP  {
 
 // ----------  Constructors and Assignment:

--- a/Vector/src/BoostZ.cc
+++ b/Vector/src/BoostZ.cc
@@ -17,6 +17,9 @@
 #include "CLHEP/Vector/LorentzRotation.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
+#include <iostream>
+
 namespace CLHEP  {
 
 // ----------  Constructors and Assignment:

--- a/Vector/src/EulerAngles.cc
+++ b/Vector/src/EulerAngles.cc
@@ -26,6 +26,7 @@
 
 #include "CLHEP/Vector/ThreeVector.h"
 
+#include <cmath>
 #include <iostream>
 
 namespace CLHEP  {

--- a/Vector/src/LorentzRotation.cc
+++ b/Vector/src/LorentzRotation.cc
@@ -17,8 +17,9 @@
 #include "CLHEP/Vector/LorentzRotation.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
-#include <iostream>
+#include <cmath>
 #include <iomanip>
+#include <iostream>
 
 namespace CLHEP  {
 

--- a/Vector/src/LorentzRotationC.cc
+++ b/Vector/src/LorentzRotationC.cc
@@ -17,6 +17,7 @@
 #include "CLHEP/Vector/ZMxpv.h"
 
 #include <cmath>
+#include <iostream>
 
 namespace CLHEP  {
 

--- a/Vector/src/LorentzRotationD.cc
+++ b/Vector/src/LorentzRotationD.cc
@@ -13,6 +13,9 @@
 #include "CLHEP/Vector/defs.h"
 #include "CLHEP/Vector/LorentzRotation.h"
 
+#include <cmath>
+#include <iostream>
+
 namespace CLHEP  {
 
 // ----------  Decomposition:

--- a/Vector/src/LorentzVector.cc
+++ b/Vector/src/LorentzVector.cc
@@ -17,6 +17,7 @@
 #include "CLHEP/Vector/LorentzVector.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
 #include <iostream>
 
 namespace CLHEP  {

--- a/Vector/src/LorentzVectorB.cc
+++ b/Vector/src/LorentzVectorB.cc
@@ -18,6 +18,8 @@
 #include "CLHEP/Vector/LorentzVector.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
+#include <iostream>
 namespace CLHEP  {
 
 //-*********

--- a/Vector/src/LorentzVectorC.cc
+++ b/Vector/src/LorentzVectorC.cc
@@ -20,6 +20,7 @@
 #include "CLHEP/Vector/LorentzVector.h"
 
 #include <cmath>
+#include <iostream>
 
 namespace CLHEP  {
 

--- a/Vector/src/LorentzVectorK.cc
+++ b/Vector/src/LorentzVectorK.cc
@@ -17,6 +17,7 @@
 #include "CLHEP/Vector/ZMxpv.h"
 
 #include <cmath>
+#include <iostream>
 
 namespace CLHEP  {
 

--- a/Vector/src/RotationC.cc
+++ b/Vector/src/RotationC.cc
@@ -18,6 +18,7 @@
 #include "CLHEP/Vector/ZMxpv.h"
 
 #include <cmath>
+#include <iostream>
 
 namespace CLHEP  {
 

--- a/Vector/src/RotationE.cc
+++ b/Vector/src/RotationE.cc
@@ -21,6 +21,7 @@
 #include "CLHEP/Units/PhysicalConstants.h"
 
 #include <cmath>
+#include <iostream>
 #include <stdlib.h>
 
 namespace CLHEP  {

--- a/Vector/src/SpaceVectorR.cc
+++ b/Vector/src/SpaceVectorR.cc
@@ -18,6 +18,9 @@
 #include "CLHEP/Vector/EulerAngles.h"
 #include "CLHEP/Vector/ZMxpv.h"
 
+#include <cmath>
+#include <iostream>
+
 namespace CLHEP  {
 
 //-************************

--- a/Vector/test/testRotationAxis.cc
+++ b/Vector/test/testRotationAxis.cc
@@ -2,6 +2,8 @@
 #include "CLHEP/Vector/ThreeVector.h"
 #include "CLHEP/Vector/Rotation.h"
 #include <assert.h>
+#include <cmath>
+#include <iostream>
 
 bool equal(double a, double b) {
   const double eps = 1e-9;

--- a/cmake/Modules/ClhepBuildLibrary.cmake
+++ b/cmake/Modules/ClhepBuildLibrary.cmake
@@ -41,6 +41,13 @@ macro(clhep_build_library package)
         OUTPUT_NAME CLHEP-${package}-${VERSION}
       )
 
+  # Do not add -Dname_EXPORTS to the command-line when building files in this
+  # target. Doing so is actively harmful for the modules build because it
+  # creates extra module variants, and not useful because we don't use these
+  # macros.
+  SET_TARGET_PROPERTIES(${package} PROPERTIES DEFINE_SYMBOL "")
+  SET_TARGET_PROPERTIES(${package}S PROPERTIES DEFINE_SYMBOL "")
+
   target_link_libraries(${package}  ${package_library_list} )
   target_link_libraries(${package}S ${package_library_list_static} )
 
@@ -73,6 +80,12 @@ macro(clhep_build_libclhep )
       PROPERTIES 
         OUTPUT_NAME CLHEP-${VERSION}
       )
+  # Do not add -Dname_EXPORTS to the command-line when building files in this
+  # target. Doing so is actively harmful for the modules build because it
+  # creates extra module variants, and not useful because we don't use these
+  # macros.
+  SET_TARGET_PROPERTIES(CLHEP PROPERTIES DEFINE_SYMBOL "")
+  SET_TARGET_PROPERTIES(CLHEPS PROPERTIES DEFINE_SYMBOL "")
 
   # export creates library dependency files for CLHEPConfig.cmake
   INSTALL(TARGETS CLHEP CLHEPS

--- a/cmake/Modules/ClhepCopyHeaders.cmake
+++ b/cmake/Modules/ClhepCopyHeaders.cmake
@@ -45,5 +45,10 @@ macro (clhep_copy_headers )
                   ${CLHEP_BINARY_DIR}/CLHEP/ClhepVersion.h  @ONLY )
   INSTALL (FILES ${CLHEP_BINARY_DIR}/CLHEP/ClhepVersion.h
            DESTINATION include/CLHEP )
+
+  # handle the module.modulemap file
+  CONFIGURE_FILE( ${CLHEP_SOURCE_DIR}/module.modulemap ${CLHEP_BINARY_DIR}/module.modulemap COPYONLY )
+  INSTALL (FILES ${CLHEP_BINARY_DIR}/CLHEP/module.modulemap
+           DESTINATION include )
   
 endmacro (clhep_copy_headers)

--- a/module.modulemap
+++ b/module.modulemap
@@ -1,0 +1,121 @@
+module clhep {
+  export *
+  requires cplusplus
+  umbrella "CLHEP"
+  module * { export *}
+
+  // The headers in this module are semantically one translation unit.
+  // The main header is AbsFunction.hh which then defines the rest
+  // implementing a PP macro-based covariant return type.
+  module CLHEP_AbsFunction_hh {
+    export *
+    header "CLHEP/GenericFunctions/AbsFunction.hh"
+
+    header "CLHEP/GenericFunctions/ConstMinusFunction.hh"
+    header "CLHEP/GenericFunctions/ConstOverFunction.hh"
+    header "CLHEP/GenericFunctions/ConstPlusFunction.hh"
+    header "CLHEP/GenericFunctions/ConstTimesFunction.hh"
+    header "CLHEP/GenericFunctions/FunctionComposition.hh"
+    header "CLHEP/GenericFunctions/FunctionConvolution.hh"
+    header "CLHEP/GenericFunctions/FunctionDifference.hh"
+    header "CLHEP/GenericFunctions/FunctionDirectProduct.hh"
+    header "CLHEP/GenericFunctions/FunctionNegation.hh"
+    header "CLHEP/GenericFunctions/FunctionNoop.hh"
+    header "CLHEP/GenericFunctions/FunctionPlusParameter.hh"
+    header "CLHEP/GenericFunctions/FunctionProduct.hh"
+    header "CLHEP/GenericFunctions/FunctionQuotient.hh"
+    header "CLHEP/GenericFunctions/FunctionSum.hh"
+    header "CLHEP/GenericFunctions/FunctionTimesParameter.hh"
+    header "CLHEP/GenericFunctions/ParameterComposition.hh"
+  }
+
+  // The headers in this module are semantically one translation unit.
+  // The main header is AbsParameter.hh which then defines the rest
+  // implementing a PP macro-based covariant return type.
+  module CLHEP_AbsParameter_hh {
+    export *
+    header "CLHEP/GenericFunctions/AbsParameter.hh"
+
+    header "CLHEP/GenericFunctions/ConstMinusParameter.hh"
+    header "CLHEP/GenericFunctions/ConstOverParameter.hh"
+    header "CLHEP/GenericFunctions/ConstPlusParameter.hh"
+    header "CLHEP/GenericFunctions/ConstTimesParameter.hh"
+    header "CLHEP/GenericFunctions/ParameterDifference.hh"
+    header "CLHEP/GenericFunctions/ParameterNegation.hh"
+    header "CLHEP/GenericFunctions/ParameterProduct.hh"
+    header "CLHEP/GenericFunctions/ParameterQuotient.hh"
+    header "CLHEP/GenericFunctions/ParameterSum.hh"
+  }
+
+  // FIXME: Exclude these headers they seem to implement a more
+  // complicated covariant return type mechanism. They should be
+  // exported from either AbsParameter.hh or AbsFunction.hh module
+  // context but seems not possible. Needs further investigation.
+  exclude header "CLHEP/GenericFunctions/DoubleParamToArgAdaptor.hh"
+  exclude header "CLHEP/GenericFunctions/DoubleParamToArgAdaptor.icc"
+  exclude header "CLHEP/GenericFunctions/ParamToArgAdaptor.hh"
+  exclude header "CLHEP/GenericFunctions/ParamToArgAdaptor.icc"
+  exclude header "CLHEP/GenericFunctions/SymToArgAdaptor.icc"
+  exclude header "CLHEP/GenericFunctions/SymToArgAdaptor.hh"
+
+  exclude header "CLHEP/RefCount/ZMuseCount.icc"
+
+  // For ZMthrowA macro
+  textual header "CLHEP/Vector/ZMxpv.h"
+}
+
+module clhep_gsl {
+  export *
+
+  module "GenericFunctions/SphericalHarmonicFit.hh" {
+    export *
+    header "CLHEP/GenericFunctions/SphericalHarmonicFit.hh"
+  }
+  module "GenericFunctions/Legendre.hh" {
+    export *
+    header "CLHEP/GenericFunctions/Legendre.hh"
+  }
+  module "GenericFunctions/Airy.hh" {
+    export *
+    header "CLHEP/GenericFunctions/Airy.hh"
+  }
+  module "GenericFunctions/SphericalNeumann.hh" {
+    export *
+    header "CLHEP/GenericFunctions/SphericalNeumann.hh"
+  }
+  module "GenericFunctions/Bessel.hh" {
+    export *
+    header "CLHEP/GenericFunctions/Bessel.hh"
+  }
+  module "GenericFunctions/LegendreExpansion.hh" {
+    export *
+    header "CLHEP/GenericFunctions/LegendreExpansion.hh"
+  }
+  module "GenericFunctions/AssociatedLegendre.hh" {
+    export *
+    header "CLHEP/GenericFunctions/AssociatedLegendre.hh"
+  }
+  module "GenericFunctions/SphericalBessel.hh" {
+    export *
+    header "CLHEP/GenericFunctions/SphericalBessel.hh"
+  }
+  module "GenericFunctions/SphericalHarmonicExpansion.hh" {
+    export *
+    header "CLHEP/GenericFunctions/SphericalHarmonicExpansion.hh"
+  }
+  module "GenericFunctions/LegendreFit.hh" {
+    export *
+    header "CLHEP/GenericFunctions/LegendreFit.hh"
+  }
+  module "GenericFunctions/Psi2Hydrogen.hh" {
+    export *
+    header "CLHEP/GenericFunctions/Psi2Hydrogen.hh"
+  }
+  module "GenericFunctions/EllipticIntegral.hh" {
+    export *
+    header "CLHEP/GenericFunctions/EllipticIntegral.hh"
+  }
+
+
+}
+


### PR DESCRIPTION
The C++ modules feature as described in https://clang.llvm.org/docs/Modules.html allow producing a binary header representation to avoid redundant header reparsing.

This feature is used in ROOT's dictionary system since ROOT v6.20: https://github.com/root-project/root/blob/master/README/README.CXXMODULES.md

CMSSW and other experiment migrate their dictionaries to use the provided by ROOT C++ modules support: https://github.com/cms-sw/cmssw/issues/15248

Dictionaries which transiently include clhep can be further optimized by building a separate module for CLHEP which this MR aims for.

The current patch introduces a module.modulemap file containing a mapping between a binary artifact (a module or a pcm file) and a set of header files. The C++ modules are more picky on translation unit encapsulation and thus require all headers which a translation unit uses to be included. In addition to the missing include we outline a few virtual destructors to avoid pollution of .o files with weak virtual tables.

This patch enables builds with modules via rootcling/genreflex/rootcint and enables compile-time module builds if configured like: cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-fmodules -Xclang -fmodules-local-submodule-visibility" ../clhep/

The module.modulemap file is easy to maintain as it globs for the well-behaved header files and enumerates already the ones needed special treatment.

This is a "backport" of https://gitlab.cern.ch/CLHEP/CLHEP/-/merge_requests/3 